### PR TITLE
Don't append team when no Topic name

### DIFF
--- a/tests/pathUtils.js
+++ b/tests/pathUtils.js
@@ -17,7 +17,7 @@ export function extractNames (filename = '', team) {
     sections.shift() // remove .archived from the array
   }
 
-  const topicName = (team ? (team._id.toString() + '-') : '') + decodePath(sections.shift())
+  const topicName = (team && sections[0] ? (team._id.toString() + '-') : '') + decodePath(sections.shift())
   const subtopicName = decodePath(sections.shift())
   const workoutName = decodePath(sections.shift())
 


### PR DESCRIPTION
When the `extractNames()` function will be called with no new topic name, it shouldn't append the team id to the returned value as it will result in a topic name of the form `"5846f58e71446382533f656d-"` 